### PR TITLE
Prevent logging invincibilty

### DIFF
--- a/CombatTag/com/topcat/npclib/NPCManager.java
+++ b/CombatTag/com/topcat/npclib/NPCManager.java
@@ -123,6 +123,7 @@ public class NPCManager {
 			BWorld world = getBWorld(l.getWorld());
 			NPCEntity npcEntity = new NPCEntity(this, world, name, new ItemInWorldManager(world.getWorldServer()));
 			npcEntity.setPositionRotation(l.getX(), l.getY(), l.getZ(), l.getYaw(), l.getPitch());
+            npcEntity.invulnerableTicks = 1;
 			world.getWorldServer().addEntity(npcEntity); //the right way
 			NPC npc = new HumanNPC(npcEntity);
 			npcs.put(id, npc);


### PR DESCRIPTION
Hey. I had experienced one little fun PvP time where a player would log out and combat log to gain invincibility and then log back in and abuse Minecraft's login invincibility to attack me, and then repeat this.

I did manage to win this fight, but only due to having Prot IV to his Prot I ... But anyway, this is a quick one-line fix that prevents the NPC from spawning and being invincible. Perhaps you'll want to make it an option, but I think the world would be better with this fix forced :p

Thanks for your time,
 SnoFox
