### PR TITLE
Fixed a simple mistake which returned CraftPlayer{player=<name>} instead...

### DIFF
--- a/CombatTag/com/trc202/CombatTagListeners/NoPvpPlayerListener.java
+++ b/CombatTag/com/trc202/CombatTagListeners/NoPvpPlayerListener.java
@@ -136,7 +136,7 @@ public class NoPvpPlayerListener implements Listener {
     private void alertPlayers(Player quitPlr) {
 		for(Player player: plugin.getServer().getOnlinePlayers()){
 			if(player.hasPermission("combattag.alert")){
-				player.sendMessage(ChatColor.RED + "[CombatTag] " + quitPlr + " has PvPLogged!");
+				player.sendMessage(ChatColor.RED + "[CombatTag] " + quitPlr.getName() + " has PvPLogged!");
 			}
 		}
 		


### PR DESCRIPTION
... of the actual name.

-- Sorry for making a PR on a such a small little change. I figured it'd be easier, but who knows. Anyway, I just noticed that with the new alert system alerting players with the permission that someone combat tag, it returned CraftPlayer instead of their string name. Easy fix though :)
